### PR TITLE
ci(travis): Add node8 job. Remove npm prune

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ cache:
 notifications:
   email: false
 node_js:
+  - '8'
   - '7'
   - '6'
-before_script:
-  - npm prune
 after_success:
   - npm run semantic-release
 branches:


### PR DESCRIPTION
Add node8 job for semantic-release v8 to work.
Remove npm prune as there is no build step